### PR TITLE
feat(Cart): persist cart in local storage and toggle "Add to Cart" button

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,10 +14,28 @@ export interface Game {
 }
 
 export default function Home() {
-    //State constants
+    // List State
     const [games, setGames] = useState<Game[]>([]);
+    // Loading State
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    // Cart State
+    const [cart, setCart] = useState<Game[]>([]);
+    //Params constants
     const [searchParams, setSearchParams] = useState<URLSearchParams | null>(null); // Para asegurarnos de que el código solo se ejecute en el cliente.
+
+    // Check local storage for the cart on initial load
+    useEffect(() => {
+        const storedCart = localStorage.getItem('cart');
+        if(storedCart){
+            setCart(JSON.parse(storedCart));
+        }
+    }, []);
+
+    // Function to update the cart in local storage
+    const updateCartInLocalStorage = (newCart: Game[]) => {
+        setCart(newCart);
+        localStorage.setItem('cart', JSON.stringify(newCart));
+    };
 
     useEffect(() => {
         // Check if it's running in the client side
@@ -51,6 +69,16 @@ export default function Home() {
         fetchGames().then(r=>console.log('data: ', r));
     }, [genre, page]);
 
+    // Handle adding/removing games from the cart
+    const handleCartAction = (game: Game) => {
+        const updatedCart = cart.some(cartItem => cartItem.id === game.id)
+            ? cart.filter(cartItem => cartItem.id !== game.id) // Remove game if already in cart
+            : [...cart, game]; // Add game to the cart if not already added
+
+        // Update the local storage
+        updateCartInLocalStorage(updatedCart);
+    };
+
   return (
       <Suspense fallback={
           <div className='flex justify-center align-middle'>
@@ -79,6 +107,10 @@ export default function Home() {
                                   image={game.image}
                                   genre={game.genre}
                                   isNew={game.isNew}
+                                  // Check if the game is in the cart
+                                  isInCart={cart.some(cartItem => cartItem.id === game.id)}
+                                  // Handle add/remove from cart
+                                  onCartAction={() => handleCartAction(game)}
                               />
                           ))}
                       </div>

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -10,10 +10,12 @@ interface ProductCardProps {
     image: string;
     genre: string;
     isNew: boolean;
+    isInCart: boolean;
+    onCartAction: () => void;
 }
 
 export const ProductCard: React.FC<ProductCardProps> = (
-    { name, price, image, genre, isNew }
+    { name, price, image, genre, isNew, isInCart, onCartAction }
 ) => {
     return (
         <div className='w-[380px] h-auto max-h-[456px] px-8 py-8 border border-[#8F8F8F] rounded-2xl'>
@@ -51,11 +53,12 @@ export const ProductCard: React.FC<ProductCardProps> = (
                 {/* Add to Cart Button */}
                 <div className='flex w-full justify-center mt-4'>
                     <button
+                        onClick={onCartAction}
                         className='font-archivo w-full text-16 font-bold tracking-[0.5px]
                         text-gray-dark border border-[#3B3B3B] rounded-2xl px-4 py-2
                         transition-all hover:bg-[#3B3B3B] hover:text-white'
                     >
-                        ADD TO CART
+                        {isInCart ? 'REMOVE' : 'ADD TO CART'}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
This pull request introduces the implementation of cart persistence in local storage and dynamic button text toggling for adding and removing items from the cart. Below are the details:

#### Changes Included:

1. **Cart Persistance:**
    - Implemented local storage to persist cart items across page reloads.
    - Added logic to load cart items from local storage when the page loads.

2. **"Add to Cart" Button:**
    - The "Add to Cart" button now toggles between "Add" and "Remove" based on the item's presence in the cart.
    - When clicked, the button adds or removes the item from the cart and updates local storage accordingly.

3. **Prodcuts Card Update:**
    - Updated the `ProductCard` component to reflect the current state of the cart and dynamically adjust the button text.